### PR TITLE
Improve AES key derivation and IV handling

### DIFF
--- a/app/src/main/java/com/devusercode/upchat/adapter/viewholder/ReceivedImageViewHolder.kt
+++ b/app/src/main/java/com/devusercode/upchat/adapter/viewholder/ReceivedImageViewHolder.kt
@@ -17,6 +17,7 @@ import com.devusercode.upchat.adapter.MessageAdapter
 import com.devusercode.upchat.models.Message
 import com.devusercode.upchat.security.AES
 import com.devusercode.upchat.security.MAC
+import com.devusercode.upchat.security.MessageIntegrity
 import com.devusercode.upchat.utils.GetTimeAgo
 
 class ReceivedImageViewHolder(private var view: View) : RecyclerView.ViewHolder(view) {
@@ -31,30 +32,17 @@ class ReceivedImageViewHolder(private var view: View) : RecyclerView.ViewHolder(
 
     @RequiresApi(Build.VERSION_CODES.S)
     fun bind(model: Message, cid: String, uid: String) {
-        val aes = AES(
-            AES.buildSharedSecret(model.senderId, uid),
-            cid
-        )
-        val mac = MAC(cid)
+        val sharedSecret = AES.buildSharedSecret(model.senderId, uid)
+        val aes = AES(sharedSecret, cid)
+        val mac = MAC(sharedSecret, cid)
 
-        var message = model.message
+        val decrypted = model.message?.let { aes.decrypt(it) } ?: ""
+        val payload = MessageIntegrity.canonicalize(model)
+        val isVerified = mac.verify(payload, model.mac)
 
-        if (model.message != null) {
-            message = aes.decrypt(model.message!!)
-        }
+        verified.visibility = if (isVerified) View.VISIBLE else View.GONE
 
-        if (model.mac != null) {
-            val messageMac = mac.generate(message!!)
-            val verify = mac.verifyMAC(model.mac!!, messageMac)
-
-            if (verify) {
-                verified.visibility = View.VISIBLE
-            } else {
-                verified.visibility = View.GONE
-            }
-        }
-
-        messageView.text = message
+        messageView.text = decrypted
         timeView.text = GetTimeAgo.parse(model.timestamp!!)
 
         Log.d(TAG, "Url: ${model.url}")

--- a/app/src/main/java/com/devusercode/upchat/adapter/viewholder/ReceivedImageViewHolder.kt
+++ b/app/src/main/java/com/devusercode/upchat/adapter/viewholder/ReceivedImageViewHolder.kt
@@ -31,7 +31,10 @@ class ReceivedImageViewHolder(private var view: View) : RecyclerView.ViewHolder(
 
     @RequiresApi(Build.VERSION_CODES.S)
     fun bind(model: Message, cid: String, uid: String) {
-        val aes = AES(uid)
+        val aes = AES(
+            AES.buildSharedSecret(model.senderId, uid),
+            cid
+        )
         val mac = MAC(cid)
 
         var message = model.message

--- a/app/src/main/java/com/devusercode/upchat/adapter/viewholder/ReceivedMessageViewHolder.kt
+++ b/app/src/main/java/com/devusercode/upchat/adapter/viewholder/ReceivedMessageViewHolder.kt
@@ -32,7 +32,10 @@ class ReceivedMessageViewHolder(view: View) : RecyclerView.ViewHolder(view) {
     }
 
     fun bind(model: Message, cid: String, uid: String) {
-        val aes = AES(uid)
+        val aes = AES(
+            AES.buildSharedSecret(model.senderId, uid),
+            cid
+        )
         val mac = MAC(cid)
 
         val messageDecrypted = aes.decrypt(model.message!!)

--- a/app/src/main/java/com/devusercode/upchat/adapter/viewholder/ReceivedMessageViewHolder.kt
+++ b/app/src/main/java/com/devusercode/upchat/adapter/viewholder/ReceivedMessageViewHolder.kt
@@ -11,6 +11,7 @@ import com.devusercode.upchat.R
 import com.devusercode.upchat.models.Message
 import com.devusercode.upchat.security.AES
 import com.devusercode.upchat.security.MAC
+import com.devusercode.upchat.security.MessageIntegrity
 import com.devusercode.upchat.utils.GetTimeAgo
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -32,26 +33,25 @@ class ReceivedMessageViewHolder(view: View) : RecyclerView.ViewHolder(view) {
     }
 
     fun bind(model: Message, cid: String, uid: String) {
-        val aes = AES(
-            AES.buildSharedSecret(model.senderId, uid),
-            cid
-        )
-        val mac = MAC(cid)
+        val sharedSecret = AES.buildSharedSecret(model.senderId, uid)
+        val aes = AES(sharedSecret, cid)
+        val mac = MAC(sharedSecret, cid)
 
-        val messageDecrypted = aes.decrypt(model.message!!)
+        val decrypted = model.message?.let { aes.decrypt(it) } ?: ""
+        val payload = MessageIntegrity.canonicalize(model)
+        val hasMac = model.mac != null
+        val isVerified = mac.verify(payload, model.mac)
 
-        if (model.mac != null) {
-            val messageMac = mac.generate(messageDecrypted)
-            val verify = mac.verifyMAC(model.mac!!, messageMac)
-
-            if (verify) {
-                verified.setImageResource(R.drawable.ic_verified_white)
-            } else {
-                verified.setImageResource(R.drawable.ic_round_error_white)
-            }
+        if (hasMac) {
+            verified.visibility = View.VISIBLE
+            verified.setImageResource(
+                if (isVerified) R.drawable.ic_verified_white else R.drawable.ic_round_error_white
+            )
+        } else {
+            verified.visibility = View.GONE
         }
 
-        message.text = messageDecrypted
+        message.text = decrypted
         time.text = GetTimeAgo.parse(model.timestamp!!)
     }
 }

--- a/app/src/main/java/com/devusercode/upchat/adapter/viewholder/SentImageViewHolder.kt
+++ b/app/src/main/java/com/devusercode/upchat/adapter/viewholder/SentImageViewHolder.kt
@@ -31,7 +31,10 @@ class SentImageViewHolder(private var view: View) : RecyclerView.ViewHolder(view
 
     @RequiresApi(Build.VERSION_CODES.S)
     fun bind(model: Message, cid: String, uid: String) {
-        val aes = AES(uid)
+        val aes = AES(
+            AES.buildSharedSecret(model.senderId, uid),
+            cid
+        )
         val mac = MAC(cid)
 
         var message = model.message

--- a/app/src/main/java/com/devusercode/upchat/adapter/viewholder/SentImageViewHolder.kt
+++ b/app/src/main/java/com/devusercode/upchat/adapter/viewholder/SentImageViewHolder.kt
@@ -17,6 +17,7 @@ import com.devusercode.upchat.adapter.MessageAdapter
 import com.devusercode.upchat.models.Message
 import com.devusercode.upchat.security.AES
 import com.devusercode.upchat.security.MAC
+import com.devusercode.upchat.security.MessageIntegrity
 import com.devusercode.upchat.utils.GetTimeAgo
 
 class SentImageViewHolder(private var view: View) : RecyclerView.ViewHolder(view) {
@@ -31,30 +32,17 @@ class SentImageViewHolder(private var view: View) : RecyclerView.ViewHolder(view
 
     @RequiresApi(Build.VERSION_CODES.S)
     fun bind(model: Message, cid: String, uid: String) {
-        val aes = AES(
-            AES.buildSharedSecret(model.senderId, uid),
-            cid
-        )
-        val mac = MAC(cid)
+        val sharedSecret = AES.buildSharedSecret(model.senderId, uid)
+        val aes = AES(sharedSecret, cid)
+        val mac = MAC(sharedSecret, cid)
 
-        var message = model.message
+        val decrypted = model.message?.let { aes.decrypt(it) } ?: ""
+        val payload = MessageIntegrity.canonicalize(model)
+        val isVerified = mac.verify(payload, model.mac)
 
-        if (model.message != null) {
-            message = aes.decrypt(model.message!!)
-        }
+        verified.visibility = if (isVerified) View.VISIBLE else View.GONE
 
-        if (model.mac != null) {
-            val messageMac = mac.generate(message!!)
-            val verify = mac.verifyMAC(model.mac!!, messageMac)
-
-            if (verify) {
-                verified.visibility = View.VISIBLE
-            } else {
-                verified.visibility = View.GONE
-            }
-        }
-
-        messageView.text = message
+        messageView.text = decrypted
         timeView.text = GetTimeAgo.parse(model.timestamp!!)
 
         Log.d(TAG, "Url: ${model.url}")

--- a/app/src/main/java/com/devusercode/upchat/adapter/viewholder/SentMessageViewHolder.kt
+++ b/app/src/main/java/com/devusercode/upchat/adapter/viewholder/SentMessageViewHolder.kt
@@ -13,6 +13,7 @@ import com.devusercode.upchat.adapter.MessageAdapter
 import com.devusercode.upchat.models.Message
 import com.devusercode.upchat.security.AES
 import com.devusercode.upchat.security.MAC
+import com.devusercode.upchat.security.MessageIntegrity
 import com.devusercode.upchat.utils.GetTimeAgo
 
 class SentMessageViewHolder(view: View) : RecyclerView.ViewHolder(view) {
@@ -34,26 +35,17 @@ class SentMessageViewHolder(view: View) : RecyclerView.ViewHolder(view) {
 
     @RequiresApi(Build.VERSION_CODES.O)
     fun bind(model: Message, cid: String, uid: String) {
-        val aes = AES(
-            AES.buildSharedSecret(model.senderId, uid),
-            cid
-        )
-        val mac = MAC(cid)
+        val sharedSecret = AES.buildSharedSecret(model.senderId, uid)
+        val aes = AES(sharedSecret, cid)
+        val mac = MAC(sharedSecret, cid)
 
-        val messageDecrypted = aes.decrypt(model.message!!)
+        val decrypted = model.message?.let { aes.decrypt(it) } ?: ""
+        val payload = MessageIntegrity.canonicalize(model)
+        val isVerified = mac.verify(payload, model.mac)
 
-        if (model.mac != null) {
-            val messageMac = mac.generate(messageDecrypted)
-            val verify = mac.verifyMAC(model.mac!!, messageMac)
+        verified.visibility = if (isVerified) View.VISIBLE else View.GONE
 
-            if (verify) {
-                verified.visibility = View.VISIBLE
-            } else {
-                verified.visibility = View.GONE
-            }
-        }
-
-        message.text = messageDecrypted
+        message.text = decrypted
         time.text = GetTimeAgo.parse(model.timestamp!!)
 
         cardview.setOnLongClickListener { view: View ->

--- a/app/src/main/java/com/devusercode/upchat/adapter/viewholder/SentMessageViewHolder.kt
+++ b/app/src/main/java/com/devusercode/upchat/adapter/viewholder/SentMessageViewHolder.kt
@@ -34,7 +34,10 @@ class SentMessageViewHolder(view: View) : RecyclerView.ViewHolder(view) {
 
     @RequiresApi(Build.VERSION_CODES.O)
     fun bind(model: Message, cid: String, uid: String) {
-        val aes = AES(uid)
+        val aes = AES(
+            AES.buildSharedSecret(model.senderId, uid),
+            cid
+        )
         val mac = MAC(cid)
 
         val messageDecrypted = aes.decrypt(model.message!!)

--- a/app/src/main/java/com/devusercode/upchat/security/AES.kt
+++ b/app/src/main/java/com/devusercode/upchat/security/AES.kt
@@ -1,49 +1,110 @@
 package com.devusercode.upchat.security
 
+import android.util.Base64
 import java.nio.charset.StandardCharsets
+import java.security.SecureRandom
+import javax.crypto.BadPaddingException
 import javax.crypto.Cipher
+import javax.crypto.IllegalBlockSizeException
+import javax.crypto.Mac
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
-import android.util.Base64
-import android.util.Log
-import javax.crypto.IllegalBlockSizeException
 
-class AES(private val secretKey: String) {
-    private val TAG = "AES"
+class AES(private val sharedSecret: String, private val salt: String) {
     private val algorithm = "AES/CBC/PKCS5Padding"
+    private val hkdfAlgorithm = "HmacSHA256"
     private val keySize = 16 // 128-bit key
     private val ivSize = 16 // 128-bit IV
+    private val secureRandom = SecureRandom()
+    private val derivedKey: SecretKeySpec by lazy {
+        val keyMaterial = hkdf(
+            sharedSecret.toByteArray(StandardCharsets.UTF_8),
+            salt.toByteArray(StandardCharsets.UTF_8),
+            "UpChat-AES-Key".toByteArray(StandardCharsets.UTF_8),
+            keySize
+        )
+        SecretKeySpec(keyMaterial, "AES")
+    }
 
     fun encrypt(plainText: String): String {
-        val keyData = secretKey.toByteArray(StandardCharsets.UTF_8).copyOf(keySize)
-        val ivData = ByteArray(ivSize)
-
         val cipher = Cipher.getInstance(algorithm)
-        cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(keyData, "AES"), IvParameterSpec(ivData))
+        val iv = ByteArray(ivSize)
+        secureRandom.nextBytes(iv)
+
+        cipher.init(Cipher.ENCRYPT_MODE, derivedKey, IvParameterSpec(iv))
 
         val encryptedBytes = cipher.doFinal(plainText.toByteArray(StandardCharsets.UTF_8))
+        val ivAndCiphertext = ByteArray(iv.size + encryptedBytes.size)
+        System.arraycopy(iv, 0, ivAndCiphertext, 0, iv.size)
+        System.arraycopy(encryptedBytes, 0, ivAndCiphertext, iv.size, encryptedBytes.size)
 
-        return Base64.encodeToString(encryptedBytes, Base64.DEFAULT)
+        return Base64.encodeToString(ivAndCiphertext, Base64.NO_WRAP)
     }
 
     fun decrypt(encryptedText: String): String {
         return try {
-            val keyData = secretKey.toByteArray(StandardCharsets.UTF_8).copyOf(keySize)
-            val ivData = ByteArray(ivSize)
+            val ivAndCiphertext = Base64.decode(encryptedText, Base64.DEFAULT)
+
+            if (ivAndCiphertext.size < ivSize) {
+                throw IllegalArgumentException("Ciphertext too short")
+            }
+
+            val iv = ivAndCiphertext.copyOfRange(0, ivSize)
+            val ciphertext = ivAndCiphertext.copyOfRange(ivSize, ivAndCiphertext.size)
 
             val cipher = Cipher.getInstance(algorithm)
-            cipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(keyData, "AES"), IvParameterSpec(ivData))
+            cipher.init(Cipher.DECRYPT_MODE, derivedKey, IvParameterSpec(iv))
 
-            val encryptedBytes = Base64.decode(encryptedText, Base64.DEFAULT)
-            val decryptedBytes = cipher.doFinal(encryptedBytes)
+            val decryptedBytes = cipher.doFinal(ciphertext)
 
             String(decryptedBytes, StandardCharsets.UTF_8)
         } catch (e: Exception) {
-            if (e !is IllegalArgumentException && e !is javax.crypto.BadPaddingException && e !is IllegalBlockSizeException) {
+            if (e !is IllegalArgumentException && e !is BadPaddingException && e !is IllegalBlockSizeException) {
                 throw e
             } else {
-                return encryptedText
+                encryptedText
             }
+        }
+    }
+
+    private fun hkdf(secret: ByteArray, salt: ByteArray, info: ByteArray, size: Int): ByteArray {
+        val mac = Mac.getInstance(hkdfAlgorithm)
+
+        val actualSalt = if (salt.isNotEmpty()) salt else ByteArray(mac.macLength)
+        mac.init(SecretKeySpec(actualSalt, hkdfAlgorithm))
+        val prk = mac.doFinal(secret)
+
+        mac.init(SecretKeySpec(prk, hkdfAlgorithm))
+
+        val result = ByteArray(size)
+        var previous = ByteArray(0)
+        var bytesGenerated = 0
+        var counter = 1
+
+        while (bytesGenerated < size) {
+            mac.update(previous)
+            mac.update(info)
+            mac.update(counter.toByte())
+
+            val output = mac.doFinal()
+            val bytesToCopy = minOf(output.size, size - bytesGenerated)
+            System.arraycopy(output, 0, result, bytesGenerated, bytesToCopy)
+
+            previous = output
+            bytesGenerated += bytesToCopy
+            counter++
+        }
+
+        return result
+    }
+
+    companion object {
+        fun buildSharedSecret(vararg identifiers: String?): String {
+            val nonNullIdentifiers = identifiers.filterNotNull()
+
+            require(nonNullIdentifiers.isNotEmpty()) { "At least one identifier is required" }
+
+            return nonNullIdentifiers.sorted().joinToString(":")
         }
     }
 }

--- a/app/src/main/java/com/devusercode/upchat/security/Hkdf.kt
+++ b/app/src/main/java/com/devusercode/upchat/security/Hkdf.kt
@@ -1,0 +1,38 @@
+package com.devusercode.upchat.security
+
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+internal object Hkdf {
+    private const val HKDF_ALGORITHM = "HmacSHA256"
+
+    fun derive(secret: ByteArray, salt: ByteArray, info: ByteArray, size: Int): ByteArray {
+        val mac = Mac.getInstance(HKDF_ALGORITHM)
+        val actualSalt = if (salt.isNotEmpty()) salt else ByteArray(mac.macLength)
+        mac.init(SecretKeySpec(actualSalt, HKDF_ALGORITHM))
+        val prk = mac.doFinal(secret)
+
+        mac.init(SecretKeySpec(prk, HKDF_ALGORITHM))
+
+        val result = ByteArray(size)
+        var previous = ByteArray(0)
+        var bytesGenerated = 0
+        var counter = 1
+
+        while (bytesGenerated < size) {
+            mac.update(previous)
+            mac.update(info)
+            mac.update(counter.toByte())
+
+            val output = mac.doFinal()
+            val bytesToCopy = minOf(output.size, size - bytesGenerated)
+            System.arraycopy(output, 0, result, bytesGenerated, bytesToCopy)
+
+            previous = output
+            bytesGenerated += bytesToCopy
+            counter++
+        }
+
+        return result
+    }
+}

--- a/app/src/main/java/com/devusercode/upchat/security/MessageIntegrity.kt
+++ b/app/src/main/java/com/devusercode/upchat/security/MessageIntegrity.kt
@@ -1,0 +1,51 @@
+package com.devusercode.upchat.security
+
+import com.devusercode.upchat.Key
+import com.devusercode.upchat.models.Message
+import com.devusercode.upchat.models.MessageTypes
+
+object MessageIntegrity {
+    fun canonicalize(values: Map<String, String?>): String {
+        val sortedEntries = values.entries
+            .filter { it.value != null }
+            .sortedBy { it.key }
+
+        val builder = StringBuilder()
+        for ((key, value) in sortedEntries) {
+            builder.append(key.length)
+                .append(':')
+                .append(key)
+                .append('=')
+                .append(value!!.length)
+                .append(':')
+                .append(value)
+                .append(';')
+        }
+
+        return builder.toString()
+    }
+
+    fun canonicalize(message: Message): String {
+        val values = linkedMapOf<String, String?>()
+
+        message.message?.let { values[Key.Message.MESSAGE] = it }
+        message.messageId?.let { values[Key.Message.ID] = it }
+
+        normalizeType(message.type)?.let { values[Key.Message.TYPE] = it }
+
+        message.url?.let { values[Key.Message.URL] = it }
+        message.checksum?.let { values[Key.Message.CHECKSUM] = it }
+        message.senderId?.let { values[Key.Message.SENDER_ID] = it }
+        message.timestamp?.let { values[Key.Message.TIMESTAMP] = it }
+
+        return canonicalize(values)
+    }
+
+    private fun normalizeType(type: Any?): String? {
+        return when (type) {
+            is MessageTypes -> type.name
+            is String -> type.uppercase()
+            else -> null
+        }
+    }
+}

--- a/app/src/main/java/com/devusercode/upchat/utils/ConversationUtil.kt
+++ b/app/src/main/java/com/devusercode/upchat/utils/ConversationUtil.kt
@@ -29,7 +29,10 @@ class ConversationUtil(
     participant: User
 ) {
     private var mac: MAC = MAC(cid)
-    private var aes: AES = AES(participant.uid!!)
+    private var aes: AES = AES(
+        AES.buildSharedSecret(user.uid, participant.uid),
+        cid
+    )
 
     companion object {
         private const val TAG = "ConversationUtil"

--- a/app/src/main/java/com/devusercode/upchat/utils/ConversationUtil.kt
+++ b/app/src/main/java/com/devusercode/upchat/utils/ConversationUtil.kt
@@ -12,6 +12,7 @@ import com.devusercode.upchat.models.MessageTypes
 import com.devusercode.upchat.models.User
 import com.devusercode.upchat.security.AES
 import com.devusercode.upchat.security.MAC
+import com.devusercode.upchat.security.MessageIntegrity
 import com.devusercode.upchat.security.SHA512
 import com.google.android.gms.tasks.Task
 import com.google.firebase.database.DataSnapshot
@@ -28,9 +29,10 @@ class ConversationUtil(
     private var user: User,
     participant: User
 ) {
-    private var mac: MAC = MAC(cid)
+    private val sharedSecret = AES.buildSharedSecret(user.uid, participant.uid)
+    private var mac: MAC = MAC(sharedSecret, cid)
     private var aes: AES = AES(
-        AES.buildSharedSecret(user.uid, participant.uid),
+        sharedSecret,
         cid
     )
 
@@ -200,9 +202,11 @@ class ConversationUtil(
         data[Key.Message.MESSAGE] = aes.encrypt(message)
         data[Key.Message.ID] = messageId
         data[Key.Message.TYPE] = MessageTypes.TEXT.toString()
-        data[Key.Message.MAC] = mac.generate(message)
         data[Key.Message.SENDER_ID] = user.uid
         data[Key.Message.TIMESTAMP] = System.currentTimeMillis().toString()
+
+        val payload = MessageIntegrity.canonicalize(data)
+        data[Key.Message.MAC] = mac.generate(payload)
 
         messagesRef.child(messageId!!).setValue(data)
     }
@@ -282,16 +286,18 @@ class ConversationUtil(
                                 checksum = SHA512.generate(uri)
                             val message = msg?.trim() ?: ""
 
-                            val data = mapOf(
+                            val data = mutableMapOf(
                                 Key.Message.MESSAGE to message,
                                 Key.Message.ID to messageId,
                                 Key.Message.TYPE to MessageTypes.IMAGE.toString(),
                                 Key.Message.URL to uri.toString(),
                                 Key.Message.CHECKSUM to checksum,
                                 Key.Message.SENDER_ID to user.uid,
-                                Key.Message.TIMESTAMP to System.currentTimeMillis().toString(),
-                                Key.Message.MAC to mac.generate(checksum)
+                                Key.Message.TIMESTAMP to System.currentTimeMillis().toString()
                             )
+
+                            val payload = MessageIntegrity.canonicalize(data)
+                            data[Key.Message.MAC] = mac.generate(payload)
 
                             Log.d(TAG, "Data: $data")
 


### PR DESCRIPTION
## Summary
- derive conversation encryption keys with HKDF using shared participant identifiers and the conversation id as salt
- switch AES encryption to use per-message random IVs prepended to ciphertext for later decryption
- update message binding helpers and conversation utilities to consume the new key derivation helper

## Testing
- `bash ./gradlew test`
