### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -1,4 +1,6 @@
 name: New Release
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/ARCOOON/UpChat/security/code-scanning/1](https://github.com/ARCOOON/UpChat/security/code-scanning/1)

To resolve the problem, we should add a `permissions` block to the workflow's YAML file. This block should be at the top-level (recommended) or, if requirements differ for individual jobs, at the job level. Since the action is primarily generating changelogs and is usually publishing a release, the minimal required permissions should be specified. The likely least privileges to start with are `contents: write` (required for creating releases or changing release assets) and possibly `pull-requests: write` if the changelog is posted as a comment or update. If unsure, begin with `contents: write`, and expand only as needed.

In practice for this workflow, add the following after the `name:` block:

```yaml
permissions:
  contents: write
```

This will restrict the `GITHUB_TOKEN` to write operations on repository contents, which suffices for release-related actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
