### PR TITLE
Potential fix for code scanning alert no. 2: Use of implicit PendingIntents

### DIFF
--- a/app/src/main/java/com/devusercode/upchat/MessagingService.kt
+++ b/app/src/main/java/com/devusercode/upchat/MessagingService.kt
@@ -50,10 +50,16 @@ class MessagingService : FirebaseMessagingService() {
 
             notificationManager.createNotificationChannel(notificationChannel)
 
-            val intent = Intent(clickAction)
+            // Fix: Map clickAction to an explicit Activity class.
+            val targetClass = when (clickAction) {
+                // TODO: Replace these example cases with your app's actual clickAction mapping
+                "OPEN_CHAT" -> ChatActivity::class.java
+                "OPEN_PROFILE" -> ProfileActivity::class.java
+                else -> MainActivity::class.java
+            }
+            val intent = Intent(this, targetClass)
             intent.putExtra("uid", uid)
             intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-
             val pendingIntent =
                 PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE)
             mBuilder.setContentIntent(pendingIntent)


### PR DESCRIPTION
Potential fix for [https://github.com/ARCOOON/UpChat/security/code-scanning/2](https://github.com/ARCOOON/UpChat/security/code-scanning/2)

To fix this vulnerability, ensure that the intent used for the `PendingIntent` is _explicit_, by specifying its target component (either via `setClass`, `setClassName`, or via an explicit constructor).  
- **General steps:** Obtain `clickAction` as before, but instead of passing it to the `Intent` constructor (which sets the action), use it only to determine which activity should launch (mapping clickAction to a specific `Activity` class), then create an explicit intent to that activity.
- **Detailed steps:**  
  - Replace `Intent(clickAction)` with an explicit intent like `Intent(this, YourTargetActivity::class.java)`.
  - If the click action is meant to launch a specific activity based on the value of `clickAction`, you need to use a controlled mapping from action string to class, e.g.  
    ```kt
    val targetClass = when (clickAction) {
        "ACTION_SOMETHING" -> SomeActivity::class.java
        "ACTION_OTHER" -> OtherActivity::class.java
        else -> DefaultActivity::class.java
    }
    val intent = Intent(this, targetClass)
    ```
  - Pass extras as before.
  - This change should be made within the lines currently building the intent for the notification in `onMessageReceived` (lines 53–56).
- **Imports/methods required:** No new imports required. You may need to define (or reference) relevant target `Activity` classes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
